### PR TITLE
Urlencode the output

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -112,7 +112,7 @@ The web service listens for POSTs to:
 
   Command:
   ::
-    curl -u user:password -d "time_stamp=$(date +%s)&host_name=host-checked&service_description=service-checked&return_code=0&output=Everything OK" http://shinken-srv:7760/push_check_result
+    curl -u user:password -d "time_stamp=$(date +%s)&host_name=host-checked&service_description=service-checked&return_code=0" --data-urlencode "output=Everything OK" http://shinken-srv:7760/push_check_result
 
   Example with more readability:
     
@@ -123,6 +123,6 @@ The web service listens for POSTs to:
     -d "time_stamp=$(date +%s)
     &host_name=host-checked
     &service_description=service-checked
-    &return_code=0
-    &output=Everything OK
+    &return_code=0"
+    --data-urlencode = "output=Everything OK"
     http://shinken-srv:7760/push_check_result


### PR DESCRIPTION
We must urlencode the output or the ";" in perfdata will cause errors.

see rfc1738

> Many URL schemes reserve certain characters for a special meaning: their appearance in the scheme-specific part of the URL has a designated semantics. If the character corresponding to an octet is reserved in a scheme, the octet must be encoded. The characters ";", "/", "?", ":", "@", "=" and "&" are the characters which may be reserved for special meaning within a scheme. No other characters may be reserved within a scheme.

http://www.ietf.org/rfc/rfc1738.txt

It took me a long time to realise.
